### PR TITLE
US 1 - fetch all merchants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "bootsnap", require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 # gem "rack-cors"
 
+gem "jsonapi-serializer"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-linux
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,8 @@ GEM
     irb (1.11.1)
       rdoc
       reline (>= 0.4.2)
+    jsonapi-serializer (2.2.0)
+      activesupport (>= 4.2)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -237,6 +239,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   faker
+  jsonapi-serializer
   pg (~> 1.1)
   pry
   puma (>= 5.0)

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::MerchantsController < ApplicationController
+  def index
+    merchants = Merchant.all
+    render json: MerchantSerializer.new(merchants)
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,0 +1,8 @@
+class Merchant < ApplicationRecord
+  validates :name, presence: true
+  
+  has_many :items
+  has_many :invoice_items, through: :items
+  has_many :invoices, through: :invoice_items
+  has_many :customers, through: :invoices
+end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,0 +1,4 @@
+class MerchantSerializer
+include JSONAPI::Serializer
+attributes :name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+
+  namespace :api do
+    namespace :v1 do
+      resources :merchants, only: [:index]
+    end
+  end
 end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -1,0 +1,8 @@
+require 'faker'
+
+FactoryBot.define do
+  factory :customer do
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+  end
+end

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -1,0 +1,7 @@
+require "faker"
+
+FactoryBot.define do
+  factory :merchant do
+    name { Faker::Company.name }
+  end
+end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Merchants API' do
+  # US 1
+  describe 'Merchants Index' do
+    it 'returns all m' do
+
+    end
+  end
+end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -3,8 +3,21 @@ require 'rails_helper'
 RSpec.describe 'Merchants API' do
   # US 1
   describe 'Merchants Index' do
-    it 'returns all m' do
+    it 'returns all merchants' do
+      create(:merchant, 3)
 
+      get '/api/v1/merchants'
+
+      expect(response).to be_successful
+
+      merchants = JSON.parse(response.body, symbolize_names: true)
+
+      expect(merchants.count).to eq(3)
+
+      merchants.each do |merchant|
+        expect(merchant).to have_key(:name)
+        expect(merchant[:name]).to be_an(String)
+      end
     end
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -4,19 +4,19 @@ RSpec.describe 'Merchants API' do
   # US 1
   describe 'Merchants Index' do
     it 'returns all merchants' do
-      create(:merchant, 3)
+      create_list(:merchant, 3)
 
       get '/api/v1/merchants'
 
       expect(response).to be_successful
 
       merchants = JSON.parse(response.body, symbolize_names: true)
+# require 'pry';binding.pry
+      expect(merchants[:data].count).to eq(3)
 
-      expect(merchants.count).to eq(3)
-
-      merchants.each do |merchant|
-        expect(merchant).to have_key(:name)
-        expect(merchant[:name]).to be_an(String)
+      merchants[:data].each do |merchant|
+        expect(merchant[:attributes]).to have_key(:name)
+        expect(merchant[:attributes][:name]).to be_an(String)
       end
     end
   end


### PR DESCRIPTION
These “index” endpoints for items and merchants should:

render a JSON representation of all records of the requested resource
always return an array of data, even if one or zero resources are found
NOT include dependent data of the resource (e.g., if you’re fetching merchants, do not send any data about merchant’s items or invoices)
follow this pattern: GET /api/v1/
Example JSON response for the Merchant resource:

{
  "data": [
    {
      "id": "1",
        "type": "merchant",
        "attributes": {
          "name": "Mike's Awesome Store",
        }
    },
    {
      "id": "2",
      "type": "merchant",
      "attributes": {
        "name": "Store of Fate",
      }
    },
    {
      "id": "3",
      "type": "merchant",
      "attributes": {
        "name": "This is the limit of my creativity",
      }
    }
  ]
}