### PR TITLE
10 us find one item

### DIFF
--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,27 +1,63 @@
 class Api::V1::Items::SearchController < ApplicationController
   before_action :validate_params, only: [:find]
-    def find
-        # require 'pry'; binding.pry
-        # params[:name] == nil && (params[:min_price] && params[:max_price]) == nil
-        # if params[:min_price] || params[:max_price]
 
-        item = Item.where("name ILIKE ?", "%#{params[:name]}%").order(name: :asc).first
+    def find
+        
+        if params.key?(:name) && (!params.key?(:min_price) && !params.key?(:max_price))
+            item = Item.where("name ILIKE ?", "%#{params[:name]}%").order(name: :asc).first
+        elsif params.key?(:min_price) && (!params.key?(:name) && !params.key?(:max_price))
+            item = Item.where("unit_price >= ?", "#{params[:min_price].to_f}").order(name: :asc).first
+        elsif params.key?(:max_price) && (!params.key?(:name) && !params.key?(:min_price))
+            item = Item.where("unit_price <= ?", "#{params[:max_price].to_f}").order(name: :asc).first
+        elsif (params.key?(:name) && params.key?(:min_price)) && !params.key?(:max_price)
+            item = Item.where("name ILIKE ? AND unit_price >= ?", "%#{params[:name]}%, #{params[:min_price].to_f}").order(name: :asc).first
+        elsif (params.key?(:name) && params.key?(:max_price)) && !params.key?(:min_price)
+            item = Item.where("name ILIKE ? AND unit_price <= ?", "%#{params[:name]}%, #{params[:max_price].to_f}").order(name: :asc).first
+        elsif (params.key?(:min_price) && params.key?(:max_price)) && !params.key?(:name)
+            item = Item.where("unit_price >= ? AND unit_price <= ?", "#{params[:min_price].to_f}, #{params[:max_price].to_f}").order(name: :asc).first
+        elsif params.key?(:name) && params.key?(:min_price) && params.key?(:max_price)
+            item = Item.where("name ILIKE ? AND unit_price >= ? AND unit_price <= ?", "%#{params[:name]}%, #{params[:min_price].to_f}, #{params[:max_price].to_f}").order(name: :asc).first
+        end
+
         if item == nil
-          raise ActionController::BadRequest, 'Item not found'
+          render json: { :data=> {
+            errors: [{status: "200", title: "Item not found"}]}}
         else 
           render json: ItemSerializer.new(item)
         end
     end
 
 private
-  def validate_params
-    has_name = params.key?(:name)
-    has_price_range = params.key?(:min_price) || params.key?(:max_price)
 
-    if has_name && has_price_range
-      raise ActionController::BadRequest, 'Cannot have name and price range at the same time'
-    elsif !has_name && !has_price_range
-      raise ActionController::BadRequest, 'Must have either name or price range'
+  def validate_params
+
+    # param existence and contradiction validations
+
+    # if name, min_price, max_price are all missing, error out
+    if params[:name].nil? && params[:min_price].nil? && params[:max_price].nil?
+        raise ActionController::BadRequest, 'Must have either name or price range'
+    # if name AND min_price OR max_price are present, error out 
+    elsif !params[:name].nil? && (!params[:min_price].nil? || !params[:max_price].nil?)
+        raise ActionController::BadRequest, 'Cannot have name and price range at the same time'
+    end
+
+    # Must write sad paths for two negative individual min and max params, and negative range when min is subtracted from max
+
+    # Negative numbers validation (only runs if params were passed in)
+
+    # if min_price was passed, and is negative, error out
+    if !params[:min_price].nil? && params[:min_price].to_f.negative?
+        raise ActionController::BadRequest, 'Minimum price cannot be negative'
+    end
+    
+    # if max_price was passed, and is negative, error out
+    if !params[:max_price].nil? && params[:max_price].to_f.negative?
+        raise ActionController::BadRequest, 'Maximum price cannot be negative'
+    end
+
+    # if min_price AND max_price were passed, and max_price minus min_price is negative, error out
+    if (!params[:min_price].nil? && !params[:max_price].nil?) && (params[:max_price] - params[:min_price]).to_f.negative?
+        raise ActionController::BadRequest, 'Price range cannot be negative'
     end
   end
 end

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::Items::SearchController < ApplicationController
     def find
-        
+        require 'pry'; binding.pry
+        render json: ItemSerializer.new(Item.find_by(params[:name]).order(name: :desc).first)
     end
 end

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -9,14 +9,8 @@ class Api::V1::Items::SearchController < ApplicationController
             item = Item.where("unit_price >= ?", params[:min_price].to_f).order(name: :asc).first
         elsif params.key?(:max_price) && (!params.key?(:name) && !params.key?(:min_price))
             item = Item.where("unit_price <= ?", params[:max_price].to_f).order(name: :asc).first
-        elsif (params.key?(:name) && params.key?(:min_price)) && !params.key?(:max_price)
-            item = Item.where("name ILIKE ? AND unit_price >= ?", "%#{params[:name]}%", params[:min_price].to_f).order(name: :asc).first
-        elsif (params.key?(:name) && params.key?(:max_price)) && !params.key?(:min_price)
-            item = Item.where("name ILIKE ? AND unit_price <= ?", "%#{params[:name]}%", params[:max_price].to_f).order(name: :asc).first
         elsif (params.key?(:min_price) && params.key?(:max_price)) && !params.key?(:name)
             item = Item.where("unit_price >= ? AND unit_price <= ?", params[:min_price].to_f, params[:max_price].to_f).order(name: :asc).first
-        elsif params.key?(:name) && params.key?(:min_price) && params.key?(:max_price)
-            item = Item.where("name ILIKE ? AND unit_price >= ? AND unit_price <= ?", "%#{params[:name]}%", params[:min_price].to_f, params[:max_price].to_f).order(name: :asc).first
         end
 
         if item == nil

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -6,17 +6,17 @@ class Api::V1::Items::SearchController < ApplicationController
         if params.key?(:name) && (!params.key?(:min_price) && !params.key?(:max_price))
             item = Item.where("name ILIKE ?", "%#{params[:name]}%").order(name: :asc).first
         elsif params.key?(:min_price) && (!params.key?(:name) && !params.key?(:max_price))
-            item = Item.where("unit_price >= ?", "#{params[:min_price].to_f}").order(name: :asc).first
+            item = Item.where("unit_price >= ?", params[:min_price].to_f).order(name: :asc).first
         elsif params.key?(:max_price) && (!params.key?(:name) && !params.key?(:min_price))
-            item = Item.where("unit_price <= ?", "#{params[:max_price].to_f}").order(name: :asc).first
+            item = Item.where("unit_price <= ?", params[:max_price].to_f).order(name: :asc).first
         elsif (params.key?(:name) && params.key?(:min_price)) && !params.key?(:max_price)
-            item = Item.where("name ILIKE ? AND unit_price >= ?", "%#{params[:name]}%, #{params[:min_price].to_f}").order(name: :asc).first
+            item = Item.where("name ILIKE ? AND unit_price >= ?", "%#{params[:name]}%", params[:min_price].to_f).order(name: :asc).first
         elsif (params.key?(:name) && params.key?(:max_price)) && !params.key?(:min_price)
-            item = Item.where("name ILIKE ? AND unit_price <= ?", "%#{params[:name]}%, #{params[:max_price].to_f}").order(name: :asc).first
+            item = Item.where("name ILIKE ? AND unit_price <= ?", "%#{params[:name]}%", params[:max_price].to_f).order(name: :asc).first
         elsif (params.key?(:min_price) && params.key?(:max_price)) && !params.key?(:name)
-            item = Item.where("unit_price >= ? AND unit_price <= ?", "#{params[:min_price].to_f}, #{params[:max_price].to_f}").order(name: :asc).first
+            item = Item.where("unit_price >= ? AND unit_price <= ?", params[:min_price].to_f, params[:max_price].to_f).order(name: :asc).first
         elsif params.key?(:name) && params.key?(:min_price) && params.key?(:max_price)
-            item = Item.where("name ILIKE ? AND unit_price >= ? AND unit_price <= ?", "%#{params[:name]}%, #{params[:min_price].to_f}, #{params[:max_price].to_f}").order(name: :asc).first
+            item = Item.where("name ILIKE ? AND unit_price >= ? AND unit_price <= ?", "%#{params[:name]}%", params[:min_price].to_f, params[:max_price].to_f).order(name: :asc).first
         end
 
         if item == nil
@@ -56,7 +56,7 @@ private
     end
 
     # if min_price AND max_price were passed, and max_price minus min_price is negative, error out
-    if (!params[:min_price].nil? && !params[:max_price].nil?) && (params[:max_price] - params[:min_price]).to_f.negative?
+    if (!params[:min_price].nil? && !params[:max_price].nil?) && (params[:max_price].to_f - params[:min_price].to_f).negative?
         raise ActionController::BadRequest, 'Price range cannot be negative'
     end
   end

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -6,11 +6,11 @@ class Api::V1::Items::SearchController < ApplicationController
         if params.key?(:name) && (!params.key?(:min_price) && !params.key?(:max_price))
             item = Item.where("name ILIKE ?", "%#{params[:name]}%").order(name: :asc).first
         elsif params.key?(:min_price) && (!params.key?(:name) && !params.key?(:max_price))
-            item = Item.where("unit_price >= ?", params[:min_price].to_f).order(name: :asc).first
+            item = Item.where("unit_price >= ?", params[:min_price]).order(name: :asc).first
         elsif params.key?(:max_price) && (!params.key?(:name) && !params.key?(:min_price))
-            item = Item.where("unit_price <= ?", params[:max_price].to_f).order(name: :asc).first
+            item = Item.where("unit_price <= ?", params[:max_price]).order(name: :asc).first
         elsif (params.key?(:min_price) && params.key?(:max_price)) && !params.key?(:name)
-            item = Item.where("unit_price >= ? AND unit_price <= ?", params[:min_price].to_f, params[:max_price].to_f).order(name: :asc).first
+            item = Item.where("unit_price >= ? AND unit_price <= ?", params[:min_price], params[:max_price]).order(name: :asc).first
         end
 
         if item == nil

--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,7 +1,27 @@
 class Api::V1::Items::SearchController < ApplicationController
+  before_action :validate_params, only: [:find]
     def find
         # require 'pry'; binding.pry
-        render json: ItemSerializer.new(Item.where("name ILIKE ?", "%#{params[:name]}%").order(name: :asc).first)
-        # Item.where("name LIKE ?", "%Choco%")c
+        # params[:name] == nil && (params[:min_price] && params[:max_price]) == nil
+        # if params[:min_price] || params[:max_price]
+
+        item = Item.where("name ILIKE ?", "%#{params[:name]}%").order(name: :asc).first
+        if item == nil
+          raise ActionController::BadRequest, 'Item not found'
+        else 
+          render json: ItemSerializer.new(item)
+        end
     end
+
+private
+  def validate_params
+    has_name = params.key?(:name)
+    has_price_range = params.key?(:min_price) || params.key?(:max_price)
+
+    if has_name && has_price_range
+      raise ActionController::BadRequest, 'Cannot have name and price range at the same time'
+    elsif !has_name && !has_price_range
+      raise ActionController::BadRequest, 'Must have either name or price range'
+    end
+  end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -14,12 +14,8 @@ class Api::V1::ItemsController < ApplicationController
     return unless check_merchant_exists(item_params[:merchant_id])
 
     item = Item.new(item_params)
-    if item.save
-      render json: ItemSerializer.new(item), status: :created
-    else
-      error_message = ErrorMessage.new(item.errors.full_messages.join(', '), 422)
-      render json: ErrorSerializer.new(error_message).serialize_json, status: :unprocessable_entity
-    end
+    item.save!  # This will raise ActiveRecord::RecordInvalid if the item is invalid
+    render json: ItemSerializer.new(item), status: :created
   end
 
   def update

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,15 +1,24 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_response 
   rescue_from ActiveRecord::RecordInvalid, with: :invalid_record_response 
+  rescue_from ActionController::BadRequest, with: :bad_request_response
 
 private
-  def not_found_response(exception)
+  # when AR query like find is used and no record of an ID exists 
+  def not_found_response(exception) 
     render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 404))
       .serialize_json, status: :not_found
   end
 
+  # when AR model fail upon saving (save, create, update)
   def invalid_record_response(exception)
     render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 422))
       .serialize_json, status: :unprocessable_entity
+  end
+
+  # when a request can't be processed due to bad parameters
+  def bad_request_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 400))
+      .serialize_json, status: :bad_request
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_response 
+  rescue_from ActiveRecord::RecordInvalid, with: :invalid_record_response 
 
 private
   def not_found_response(exception)
@@ -7,7 +8,8 @@ private
       .serialize_json, status: :not_found
   end
 
-  def bad_request_response(exception)
-    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 400))
+  def invalid_record_response(exception)
+    render json: ErrorSerializer.new(ErrorMessage.new(exception.message, 422))
+      .serialize_json, status: :unprocessable_entity
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,6 @@ Rails.application.routes.draw do
       resources :items, only: [:index, :show, :create, :update, :destroy] do
         resources :merchant, only: [:index], module: :items
       end
-
-      get '/items/find', to: 'items/search#find', module: :items
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
         resources :merchant, only: [:index], module: :items
       end
 
-      get '/items/find', to: 'items/search#find'
+      get '/items/find', to: 'items/search#find', module: :items
     end
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -186,7 +186,7 @@ describe "Items API" do
           
           expect(data[:errors]).to be_a(Array)
           expect(data[:errors].first[:status]).to eq("422")
-          expect(data[:errors].first[:title]).to eq("Description can't be blank")
+          expect(data[:errors].first[:title]).to eq("Validation failed: Description can't be blank")
         end
       end
     end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -457,7 +457,7 @@ describe "Items API" do
           expect(item[:data][:attributes][:merchant_id]).to eq(3)
         end
 
-        it 'can find the first item matching a min_price attribute in case-insensitive alphabetical order' do
+        it 'can find the first item matching a max_price attribute in case-insensitive alphabetical order' do
           merchant1 = create(:merchant, id: 1)
           merchant2 = create(:merchant, id: 2)
           merchant3 = create(:merchant, id: 3)
@@ -606,7 +606,7 @@ describe "Items API" do
           expect(item[:errors].first[:title]).to eq("Maximum price cannot be negative")
         end
 
-        it 'returns a 400 error if max_price is negative' do
+        it 'returns a 400 error if max_price minus min_price is negative' do
           get '/api/v1/items/find?max_price=50&min_price=51'
     
           expect(response).to_not be_successful

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -167,7 +167,7 @@ describe "Items API" do
           expect(data[:errors].first[:title]).to eq("Couldn't find Merchant without an ID")
         end
 
-        it 'returns a 422 if item attribute is missing' do
+        it "returns a 422 if item attribute is missing and can't save the item creation" do
           merchant = create(:merchant, id: 1)
 
           item_params = ({
@@ -290,7 +290,7 @@ describe "Items API" do
             expect(response.status).to eq(404)
   
             data = JSON.parse(response.body, symbolize_names: true)
-            
+            require 'pry';binding.pry
             expect(data[:errors]).to be_a(Array)
             expect(data[:errors].first[:status]).to eq("404")
             expect(data[:errors].first[:title]).to eq("Couldn't find Merchant with 'id'=999999")
@@ -409,6 +409,73 @@ describe "Items API" do
 
           expect(item[:data][:attributes]).to have_key(:merchant_id)
           expect(item[:data][:attributes][:merchant_id]).to eq(1)
+        end
+      end
+
+      describe 'Sad Path' do
+        it 'returns an error if the parameter is missing' do
+          get '/api/v1/items/find'
+
+          expect(response).to_not be_successful
+          expect(response.status).to eq(400)
+
+          data = JSON.parse(response.body, symbolize_names: true)
+
+          expect(data[:errors]).to be_a(Array)
+          expect(data[:errors].first[:status]).to eq("400")
+          expect(data[:errors].first[:title]).to eq("Must have either name or price range")
+        end
+
+        it 'returns a 400 error if the parameter is empty due to bad request' do
+          get '/api/v1/items/find?name='
+    
+          expect(response).to_not be_successful
+          expect(response.status).to eq(400)
+
+          data = JSON.parse(response.body, symbolize_names: true)
+
+          expect(data[:errors]).to be_a(Array)
+          expect(data[:errors].first[:status]).to eq("400")
+          expect(data[:errors].first[:title]).to eq("Item not found")
+        end
+
+        it 'returns a 400 error if the parameter has both name and min_price' do
+          get '/api/v1/items/find?name=ring&min_price=50'
+    
+          expect(response).to_not be_successful
+          expect(response.status).to eq(400)
+
+          data = JSON.parse(response.body, symbolize_names: true)
+
+          expect(data[:errors]).to be_a(Array)
+          expect(data[:errors].first[:status]).to eq("400")
+          expect(data[:errors].first[:title]).to eq("Cannot have name and price range at the same time")
+        end
+
+        it 'returns a 400 error if the parameter has both name and max_price' do
+          get '/api/v1/items/find?name=ring&min_price=50'
+    
+          expect(response).to_not be_successful
+          expect(response.status).to eq(400)
+
+          data = JSON.parse(response.body, symbolize_names: true)
+
+          expect(data[:errors]).to be_a(Array)
+          expect(data[:errors].first[:status]).to eq("400")
+          expect(data[:errors].first[:title]).to eq("Cannot have name and price range at the same time")
+        end
+
+        it 'returns a 400 error if the parameter has both name and min_price & max_price' do
+          get '/api/v1/items/find?name=ring&min_price=50'
+    
+          expect(response).to_not be_successful
+          expect(response.status).to eq(400)
+
+          data = JSON.parse(response.body, symbolize_names: true)
+
+          expect(data[:errors]).to be_a(Array)
+          expect(data[:errors].first[:status]).to eq("400")
+          expect(data[:errors].first[:title]).to eq("Cannot have name and price range at the same time")
         end
       end
     end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -379,29 +379,36 @@ describe "Items API" do
     # US 10
     describe 'Find One Item' do
       describe 'Happy Path' do
-        it 'can find a single item that matches a search term' do
+        it 'can find the first item in the database in case-insensitive alphabetical order if multiple matches are found (including partial names)' do
           merchant1 = create(:merchant, id: 1)
           merchant2 = create(:merchant, id: 2)
           merchant3 = create(:merchant, id: 3)
 
-          item1 = Item.create!(name: 'Hersheys', description: 'Candy', unit_price: 3.99, id: 1, merchant_id: 1)
-          item1 = Item.create!(name: 'Slim Jim', description: 'Jerky', unit_price: 2.99, id: 2, merchant_id: 1)
-          item1 = Item.create!(name: 'Nerds', description: 'Candy', unit_price: 1.99, id: 3, merchant_id: 2)
-          item1 = Item.create!(name: 'Mars', description: 'Candy', unit_price: 5.99, id: 4, merchant_id: 3)
+          item1 = Item.create!(name: 'Hersheys Chocolate', description: 'Candy', unit_price: 3.99, id: 1, merchant_id: 1)
+          item2 = Item.create!(name: 'Slim Jim', description: 'Jerky', unit_price: 2.99, id: 2, merchant_id: 1)
+          item3 = Item.create!(name: 'Nerds', description: 'Candy', unit_price: 1.99, id: 3, merchant_id: 2)
+          item4 = Item.create!(name: 'Mars Chocolate', description: 'Candy', unit_price: 5.99, id: 4, merchant_id: 3)
 
-          get '/api/v1/items/find'
+          get '/api/v1/items/find?name=choco'
 
           expect(response).to be_successful
 
           item = JSON.parse(response.body, symbolize_names: true)
 
-          # expect(item.count).to eq(1)
-          # expect(item[:data]).to be_a(Hash)
+          expect(item.count).to eq(1)
+          expect(item[:data]).to be_a(Hash)
 
-          # expect(item[:data][:attributes]).to have_key(:name) 
-          # expect(item[:data][:attributes]).to have_key(:description)    
-          # expect(item[:data][:attributes]).to have_key(:unit_price)
-          # expect(item[:data][:attributes]).to have_key(:merchant_id)
+          expect(item[:data][:attributes]).to have_key(:name)
+          expect(item[:data][:attributes].name).to be("Hersheys Chocolate")
+
+          expect(item[:data][:attributes]).to have_key(:description)
+          expect(item[:data][:attributes].description).to be("Candy")
+
+          expect(item[:data][:attributes]).to have_key(:unit_price)
+          expect(item[:data][:attributes].unit_price).to be(3.99)
+
+          expect(item[:data][:attributes]).to have_key(:merchant_id)
+          expect(item[:data][:attributes].merchant_id).to be(1)
         end
       end
     end


### PR DESCRIPTION
The endpoints will NOT follow RESTful convention. For example:

- `GET /api/vi/items/find`, find a single item which matches a search term
- `GET /api/vi/items/find_all`, find all items which match a search term
- `GET /api/vi/merchants/find`, find a single merchant which matches a search term
- `GET /api/vi/merchants/find_all`, find all merchants which match a search term

These endpoints will make use of query parameters as described below:

- return a single object, if found
- return the first object in the database in case-insensitive alphabetical order if multiple matches are found
    - e.g., if “Ring World” and “Turing” exist as merchant names, “Ring World” would be returned, even if “Turing” was created first
- allow the user to specify a 'name' query parameter:
    - for merchants, the user can send `?name=ring` and it will search the `name` field in the database table
    - for items, the user can send ?name=ring and it will search the `name` field in the database table
    - the search data in the name query parameter should require the database to do a case-insensitive search for text fields
        - e.g., searching for ‘ring’ should find ‘Turing’ and ‘Ring World’
- allow the user to send one or more price-related query parameters, applicable to items only:
    - `min_price=4.99` should look for anything with a price equal to or greater than $4.99
    - `max_price=99.99` should look for anything with a price less than or equal to $99.99
    - both `min_price` and `max_price` can be sent
- for items, the user will send EITHER the `name` parameter OR either/both of the `price` parameters
    - users should get an error if `name` and either/both of the `price` parameters are sent

Valid examples:

- `GET /api/v1/merchants/find?name=Mart`
- `GET /api/v1/items/find?name=ring`
- `GET /api/v1/items/find?min_price=50`
- `GET /api/v1/items/find?max_price=150`
- `GET /api/v1/items/find?max_price=150&min_price=50`

Invalid examples:

- `GET /api/v1/<resource>/find`
    - parameter cannot be missing
- `GET /api/v1/<resource>/find?name=`
    - parameter cannot be empty
- `GET /api/v1/items/find?name=ring&min_price=50`
    - cannot send both `name` and `min_price`
- `GET /api/v1/items/find?name=ring&max_price=50`
    - cannot send both `name` and `max_price`
- `GET /api/v1/items/find?name=ring&min_price=50&max_price=250`
    - cannot send both `name` and `min_price` and `max_price`

Example JSON response for `GET /api/v1/merchants/find?name=ring`
```
{
  "data": {
    "id": 4,
    "type": "merchant",
    "attributes": {
      "name": "Ring World"
    }
  }
}
```